### PR TITLE
Add wakeup field to iphb wait request data

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Package name and version
-AC_INIT(libiphb, 1.0.2)
+AC_INIT(libiphb, 1.1.0)
 
 AM_INIT_AUTOMAKE
 

--- a/rpm/libiphb.spec
+++ b/rpm/libiphb.spec
@@ -9,7 +9,7 @@ Name:       libiphb
 # << macros
 
 Summary:    API for IP Heartbeat service
-Version:    1.0.2
+Version:    1.1.0
 Release:    0
 Group:      System/System Control
 License:    LGPLv2+

--- a/rpm/libiphb.yaml
+++ b/rpm/libiphb.yaml
@@ -1,6 +1,6 @@
 Name: libiphb
 Summary: API for IP Heartbeat service
-Version: 1.0.2
+Version: 1.1.0
 Release: 0
 Group: System/System Control
 License: LGPLv2+

--- a/src/iphb_internal.h
+++ b/src/iphb_internal.h
@@ -47,6 +47,16 @@ struct _iphb_wait_req_t {
   unsigned short mintime;	/*!< minimum wait time in seconds, zero means use default */
   unsigned short maxtime;	/*!< maximum wait time in seconds, zero means use default */
   pid_t          pid;           /*!< client process ID (PID) */
+
+  /* Since 1.1.0 */
+  unsigned char  wakeup;	/*!< Flag for use with dsme internal waits.
+				 *   If set to non-zero value, device will
+				 *   wakeup to handle the internal wakeup
+				 *   instead of handling it while woken up
+				 *   due to external activity. */
+
+  /* Note: The size of this structure can grow up to 64 bytes without causing
+   *       binary compatibility breaks, see struct _iphb_req_t below */
 };
 
 /**@brief Message from iphbd to client ("wake up!") */


### PR DESCRIPTION
This is used internally within dsme to flag internal wait
requests that need to wake up from suspend.
