### PR TITLE
Remove unuseful extra long wait from ranged waits test

### DIFF
--- a/tests/hbtest3.c
+++ b/tests/hbtest3.c
@@ -1103,14 +1103,6 @@ static void ranges_test(int *xc)
   //                            |         |
   //                          group1      group2
 
-  /* start extra long timer, we do not expect this to trigger */
-  {
-    int d = 24 * 60 * 60;
-    hbtimer_t *t = hbtimer_create(d*3, d*4, 1);
-    t->repeats = 0;
-    timer[timers++] = t;
-  }
-
   /* fail if tests do not finish in time */
   timeout = g_timeout_add_seconds(scale(11) + 13, failure_cb, &timeout);
 


### PR DESCRIPTION
The code was used during implementation of passing long delay times to
daemon side and got committed accidentally. Now it makes the test case
fail every time and take ages to reach completion.

Remove extra long wakeup timer that has no chances of triggering.